### PR TITLE
Add new User Agent to chrome options when instantiating Chrome webdriver

### DIFF
--- a/assets/sources/base_client.py
+++ b/assets/sources/base_client.py
@@ -64,6 +64,7 @@ def cache(func):
 @cache
 def get_selenium_webdriver(cache_id=None):
     chrome_options = Options()
+    chrome_options.add_argument("--user-agent=New User Agent")
     chrome_options.add_argument("--headless")
     return webdriver.Chrome(chrome_options=chrome_options)
 
@@ -82,6 +83,7 @@ class BaseSeleniumClient:
         # if you want to use something else locally, you will need
         # to configure this yourself
         chrome_options = Options()
+        chrome_options.add_argument("--user-agent=New User Agent")
         chrome_options.add_argument("--headless")
         self.selenium = get_selenium_webdriver(
             cache_id="base_client_selenium_webdriver"


### PR DESCRIPTION
After discussions with @ecedmondson, specifying User Agent when instantiating the selenium webdriver might allow us to work around Best Buy's automated traffic blocker. The idea is that a new User Agent is created when making the request to Best Buy so that it looks like a new request from a new user. This appeared to work when testing many requests to Best Buy for the hp chromebook product.